### PR TITLE
Add Convert To TFLite Script

### DIFF
--- a/convert_tflite.py
+++ b/convert_tflite.py
@@ -1,0 +1,28 @@
+#================================================================
+#
+#   File name   : detect_mnist.py
+#   Author      : Jangmin
+#   Created date: 2020-10-05
+#   GitHub      : https://github.com/JangminSon
+#   Description : Convert Models To TF Lite
+#
+#================================================================
+import os
+os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+import cv2
+import numpy as np
+import random
+import time
+import tensorflow as tf
+from yolov3.yolov4 import Create_Yolo
+from yolov3.utils import detect_image
+from yolov3.configs import *
+
+yolo = Create_Yolo(input_size=YOLO_INPUT_SIZE, CLASSES=TRAIN_CLASSES)
+yolo.load_weights(f"./checkpoints/yolov3_custom") # use keras weights
+
+c = tf.lite.TFLiteConverter.from_keras_model(yolo)
+c.target_spec.supported_ops =[tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+
+tflite_model = c.convert()
+open("./yolov3_custom.tflite", 'wb').write(tflite_model)


### PR DESCRIPTION
Convert Check-Points Files to TFLite.
Runs on TFLite version 2.3

About the Imgae Resize Section in  [yolov3.py#L61](https://github.com/pythonlessons/TensorFlow-2.x-YOLOv3/blob/93447e939c3efeedb9f166bb17c7ad8ea8dddc39/yolov3/yolov3.py#L61)

nearest Method is not supported from earlier TFLite version. it can be solved with simply change nearest to bilinear.
